### PR TITLE
QBX Compatibility and Mistyped Metadata Fixes 

### DIFF
--- a/bridge/framework/qbx/client.lua
+++ b/bridge/framework/qbx/client.lua
@@ -20,7 +20,7 @@ function bridge.createAiPed(info)
 end
 
 function bridge.isDead()
-    return QBX.PlayerData?.metadata?.isdead
+    return QBX.PlayerData?.metadata?.isDead
 end
 
 return bridge

--- a/bridge/framework/qbx/server.lua
+++ b/bridge/framework/qbx/server.lua
@@ -1,7 +1,7 @@
 local bridge = {}
 local qbx_core = exports.qbx_core
 
-function bridge.setDeadMetadata(src)
+function bridge.setDeadMetadata(src, info)
     qbx_core:SetMetadata(src, "isDead", true)
 end
 
@@ -34,7 +34,7 @@ function bridge.deductMoney(src, amount)
 end
 
 function bridge.revivePlayer(src)
-    TriggerClientEvent("ND_Ambulance:revivePlayer", src)
+    TriggerClientEvent("ND:revivePlayer", src)
     qbx_core:SetMetadata(src, "isDead", false)
 end
 
@@ -49,7 +49,12 @@ lib.addCommand("revive", {
         }
     }
 }, function(src, args, raw)
-    bridge.revivePlayer(src)
+    local target = args.target
+    if target then
+        bridge.revivePlayer(target)
+    else
+        bridge.revivePlayer(src)
+    end
 end)
 
 return bridge

--- a/client/main.lua
+++ b/client/main.lua
@@ -339,7 +339,7 @@ local function getPedHealthPercentage(ped)
 end
 
 -- ND Core death system event.
-AddEventHandler("ND:playerEliminated", function(info)
+AddEventHandler("ND_Ambulance:playerEliminated", function(info)
     Wait(2000)
     revivePlayer()
 
@@ -360,6 +360,7 @@ end)
 
 RegisterNetEvent("ND:revivePlayer", function()
     if source == "" then return end
+    revivePlayer()
     deathState = nil
     bleeding = 0
     bodyBonesDamage = lib.table.deepclone(data_bone_settings)

--- a/client/main.lua
+++ b/client/main.lua
@@ -268,21 +268,29 @@ end
 -- set stateags and determine animation that should be playing.
 local function setDeathState(newState)
     if knockedOut or deathState == "eliminated" then return end
-
+    
     knockedOut = false
     local ped = PlayerPedId()
-
-    if LocalPlayer.state.dead and deathState == "knocked" then
+    
+    -- Check if player is already dead from metadata and preserve that state
+    local metadataState = Player(cache.serverId).state
+    if metadataState.isDead then
+        -- Use the exact metadata state instead of overriding it
+        newState = metadataState.isDead
+    elseif LocalPlayer.state.dead and deathState == "knocked" then
         newState = "eliminated"
     end
-
+    
     local state = Player(cache.serverId).state
-    state:set("isDead", newState, true)
+    -- Only set metadata if it doesn't already match the desired state
+    if not metadataState.isDead or metadataState.isDead ~= newState then
+        state:set("isDead", newState, true)
+    end
     state:set("injuries", getInjuredBoneData(bodyBonesDamage), true)
     LocalPlayer.state.dead = true
-
+    
     BlockActions(true)
-
+    
     downAnim = downAnim or getRandomDeathAnim()
     local anim = downAnim[cache.vehicle and "vehicle" or newState]
     local dict, clip = anim[1], anim[2]
@@ -294,8 +302,15 @@ local function updatePreviousPlayerDeath()
     SetPlayerHealthRechargeMultiplier(cache.playerId, 0.0)
 
     if not Bridge.isDead() then return end
+    
     revivePlayer()
-    setDeathState("knocked")
+    
+    -- Get the exact death state from metadata to ensure correct screen displays
+    local metadataState = Player(cache.serverId).state
+    local deathStateFromMetadata = metadataState.isDead
+    
+    -- Set the death state to match metadata exactly
+    setDeathState(deathStateFromMetadata)
 end
 
 local function setPlayerKnockedOut()


### PR DESCRIPTION
## Summary
This PR addresses Qbox framework compatibility issues and fixes several metadata/event name mismatches that were preventing the death system from working correctly. This directly fixes all the open qbox issues that haven't been resolved. 

## Issues
[[qbx] Fall from heights does not trigger injured screen](https://github.com/ND-Framework/ND_Ambulance/issues/31)
[[qbx] Downed/Injured state doesn't persist](https://github.com/ND-Framework/ND_Ambulance/issues/30)
[[qbx] Revive Command doesn't work during injured screen](https://github.com/ND-Framework/ND_Ambulance/issues/29)

## Changes
- Fixed metadata key from `isdead` to `isDead` for consistency
- Corrected event name from `ND_Ambulance:revivePlayer` to `ND:revivePlayer`
- Added missing `revivePlayer()` function call in event handler
- Implemented death state preservation on reconnect
- Fixed `/revive` command to properly handle target parameter

## Testing
Please verify:
- Death state persists correctly after reconnecting
- Ensure that the deathscreen appears correctly upon taking lethal/non lethal damage
- Ensure that upon revival the players metadata and health resets
- `/revive` command works
- QBX metadata properly reflects player death status